### PR TITLE
Fix bug where reason was not included in emails

### DIFF
--- a/app/Helpers/EmailClient.php
+++ b/app/Helpers/EmailClient.php
@@ -34,7 +34,7 @@ class EmailClient
 
     public function __construct(string $subject)
     {
-        $this->sender = "no-reply@datasektionen.se";
+        $this->sender = 'no-reply@datasektionen.se';
         $this->subject = $subject;
     }
 
@@ -55,19 +55,19 @@ class EmailClient
             return false;
         }
 
-        if (!preg_match("/(.*@.*\..*)(,.*@.*\..*)*/", $this->recipient)) {
+        if (!preg_match('/(.*@.*\..*)(,.*@.*\..*)*/', $this->recipient)) {
             return false;
         }
 
         $client = new Client();
         try {
-            $response = $client->post(config("spam.url"), [
-                "json" => [
-                    "to" => $this->recipient,
-                    "from" => $this->sender,
-                    "subject" => $this->subject,
-                    "html" => $this->html->render(),
-                    "key" => config("spam.api_key"),
+            $response = $client->post(config('spam.url'), [
+                'json' => [
+                    'to' => $this->recipient,
+                    'from' => $this->sender,
+                    'subject' => $this->subject,
+                    'html' => $this->html->render(),
+                    'key' => config('spam.api_key'),
                 ],
             ]);
             return $response->getStatusCode() == 200;
@@ -78,45 +78,45 @@ class EmailClient
 
     public static function sendBookingStatus(Event $event): bool
     {
-        $email = new self("Din bokning handläggs nu");
-        $email->recipient = $event->author->kth_username . "@kth.se";
-        $email->html = view("emails.reviewing")
-            ->with("user", $event->author)
-            ->with("event", $event)
-            ->with("entity", $event->entity);
+        $email = new self('Din bokning handläggs nu');
+        $email->recipient = $event->author->kth_username . '@kth.se';
+        $email->html = view('emails.reviewing')
+            ->with('user', $event->author)
+            ->with('event', $event)
+            ->with('entity', $event->entity);
         return $email->send();
     }
 
     public static function sendBookingConfirmation(Event $event): bool
     {
-        $email = new self("Din bokning är godkänd");
-        $email->recipient = $event->author->kth_username . "@kth.se";
-        $email->html = view("emails.approved")
-            ->with("user", $event->author)
-            ->with("event", $event)
-            ->with("entity", $event->entity);
+        $email = new self('Din bokning är godkänd');
+        $email->recipient = $event->author->kth_username . '@kth.se';
+        $email->html = view('emails.approved')
+            ->with('user', $event->author)
+            ->with('event', $event)
+            ->with('entity', $event->entity);
         return $email->send();
     }
 
     public static function sendBookingDeclined(Event $event): bool
     {
-        $email = new self("Din bokning blev inte godkänd");
-        $email->recipient = $event->author->kth_username . "@kth.se";
-        $email->html = view("emails.declined")
-            ->with("user", $event->author)
-            ->with("event", $event)
-            ->with("entity", $event->entity);
+        $email = new self('Din bokning blev inte godkänd');
+        $email->recipient = $event->author->kth_username . '@kth.se';
+        $email->html = view('emails.declined')
+            ->with('user', $event->author)
+            ->with('event', $event)
+            ->with('entity', $event->entity);
         return $email->send();
     }
 
     public static function sendBookingNotification(Event $event): bool
     {
-        $email = new self("Ny bokningsförfrågan för {$event->entity->name}");
+        $email = new self('Ny bokningsförfrågan för {$event->entity->name}');
         $email->recipient = $event->entity->notify_email;
-        $email->html = view("emails.notify")
-            ->with("user", $event->author)
-            ->with("event", $event)
-            ->with("entity", $event->entity);
+        $email->html = view('emails.notify')
+            ->with('user', $event->author)
+            ->with('event', $event)
+            ->with('entity', $event->entity);
         return $email->send();
     }
 
@@ -125,14 +125,14 @@ class EmailClient
         Event $event,
         array $dirty
     ): bool {
-        $email = new self("Din bokning av {$event->entity->name} ändrades");
-        $email->recipient = $event->author->kth_username . "@kth.se";
-        $email->html = view("emails.changed")
-            ->with("user", $event->author)
-            ->with("event", $event)
-            ->with("oldEvent", $oldEvent)
-            ->with("entity", $event->entity)
-            ->with("dirty", $dirty);
+        $email = new self('Din bokning av {$event->entity->name} ändrades');
+        $email->recipient = $event->author->kth_username . '@kth.se';
+        $email->html = view('emails.changed')
+            ->with('user', $event->author)
+            ->with('event', $event)
+            ->with('oldEvent', $oldEvent)
+            ->with('entity', $event->entity)
+            ->with('dirty', $dirty);
 
         return $email->send();
     }
@@ -143,27 +143,27 @@ class EmailClient
         array $dirty
     ): bool {
         $email = new self(
-            "Bokningen {$event->entity->name} ändrades och måste granskas"
+            'Bokningen {$event->entity->name} ändrades och måste granskas'
         );
         $email->recipient = $event->entity->notify_email;
-        $email->html = view("emails.changed-notify")
-            ->with("event", $event)
-            ->with("oldEvent", $oldEvent)
-            ->with("entity", $event->entity)
-            ->with("dirty", $dirty);
+        $email->html = view('emails.changed-notify')
+            ->with('event', $event)
+            ->with('oldEvent', $oldEvent)
+            ->with('entity', $event->entity)
+            ->with('dirty', $dirty);
         return $email->send();
     }
 
     public static function sendBookingDeleted(Event $event): bool
     {
-        $email = new self("Bokningen {$event->entity->name} togs bort");
+        $email = new self('Bokningen {$event->entity->name} togs bort');
         $email->recipient = $event->entity->notify_email;
-        $email->html = view("emails.deleted")
-            ->with("event", $event)
-            ->with("entity", $event->entity);
+        $email->html = view('emails.deleted')
+            ->with('event', $event)
+            ->with('entity', $event->entity);
         $sentToEntityOwner = $email->send();
 
-        $email->recipient = $event->author->kth_username . "@kth.se";
+        $email->recipient = $event->author->kth_username . '@kth.se';
         $sentToAuthor = $email->send();
 
         return $sentToEntityOwner && $sentToAuthor;

--- a/app/Helpers/EmailClient.php
+++ b/app/Helpers/EmailClient.php
@@ -120,11 +120,7 @@ class EmailClient
         return $email->send();
     }
 
-    public static function sendBookingChanged(
-        Event $oldEvent,
-        Event $event,
-        array $dirty
-    ): bool {
+    public static function sendBookingChanged(Event $oldEvent, Event $event, array $dirty): bool {
         $email = new self('Din bokning av {$event->entity->name} ändrades');
         $email->recipient = $event->author->kth_username . '@kth.se';
         $email->html = view('emails.changed')
@@ -137,11 +133,7 @@ class EmailClient
         return $email->send();
     }
 
-    public static function sendBookingChangedNotification(
-        Event $oldEvent,
-        Event $event,
-        array $dirty
-    ): bool {
+    public static function sendBookingChangedNotification(Event $oldEvent, Event $event, array $dirty): bool {
         $email = new self(
             'Bokningen {$event->entity->name} ändrades och måste granskas'
         );

--- a/app/Helpers/EmailClient.php
+++ b/app/Helpers/EmailClient.php
@@ -1,189 +1,171 @@
 <?php namespace App\Helpers;
 
-use \App\Models\Event;
+use App\Models\Event;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\View\View;
+use Throwable;
 
 class EmailClient
 {
     /**
      * The subject of the email to be sent.
-     *
      * @var string
      */
     public $subject;
 
     /**
      * The email address of the recipient.
-     *
      * @var string
      */
     public $recipient;
 
     /**
      * The email address of the sender. Must be verified by spam.
-     *
      * @var string
      */
     public $sender;
 
     /**
      * The HTML content of the email.
-     *
-     * @var string
+     * @var View
      */
     public $html;
 
-    /**
-     * Concats the given data to POST request valid format.
-     *
-     * @param array $data array of data to concat
-     * @return string
-     */
-    public function concatData()
+    public function __construct(string $subject)
     {
-        $data = [
-            'to' => $this->recipient,
-            'from' => $this->sender,
-            'subject' => $this->subject,
-            'html' => $this->html,
-            'key' => env('SPAM_API_KEY')
-        ];
-        $res = "";
-        foreach ($data as $key => $val) {
-            $res .= $key . "=" . rawurlencode($val) . "&";
-        }
-        return $res;
+        $this->sender = "no-reply@datasektionen.se";
+        $this->subject = $subject;
     }
 
     /**
      * Sends email with current $subject, $recipient, $sender and $html.
      *
+     * Possible to fail to send if:
+     * - No recipient set
+     * - Recipient is not an email address
+     * - Failed to render template
+     * - Error in POST request to email system
+     *
      * @return boolean
      */
-    public function send()
+    public function send(): bool
     {
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, env('SPAM_API_URL'));
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $this->concatData());
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_exec($ch);
-        curl_close($ch);
-        return true;
+        if ($this->recipient === null) {
+            return false;
+        }
+
+        if (!preg_match("/(.*@.*\..*)(,.*@.*\..*)*/", $this->recipient)) {
+            return false;
+        }
+
+        $client = new Client();
+        try {
+            $response = $client->post(config("spam.url"), [
+                "json" => [
+                    "to" => $this->recipient,
+                    "from" => $this->sender,
+                    "subject" => $this->subject,
+                    "html" => $this->html->render(),
+                    "key" => config("spam.api_key"),
+                ],
+            ]);
+            return $response->getStatusCode() == 200;
+        } catch (Throwable | GuzzleException $e) {
+            return false;
+        }
     }
 
-    public static function sendBookingStatus(Event $event)
+    public static function sendBookingStatus(Event $event): bool
     {
-        $email = new EmailClient;
+        $email = new self("Din bokning handläggs nu");
         $email->recipient = $event->author->kth_username . "@kth.se";
-        $email->sender = "no-reply@datasektionen.se";
-        $email->subject = "Din bokning handläggs nu";
-        $email->html = view('emails.reviewing')
-            ->with('user', $event->author)
-            ->with('event', $event)
-            ->with('entity', $event->entity);
-        $email->send();
+        $email->html = view("emails.reviewing")
+            ->with("user", $event->author)
+            ->with("event", $event)
+            ->with("entity", $event->entity);
+        return $email->send();
     }
 
-    public static function sendBookingConfirmation(Event $event)
+    public static function sendBookingConfirmation(Event $event): bool
     {
-        $email = new EmailClient;
+        $email = new self("Din bokning är godkänd");
         $email->recipient = $event->author->kth_username . "@kth.se";
-        $email->sender = "no-reply@datasektionen.se";
-        $email->subject = "Din bokning är godkänd";
-        $email->html = view('emails.approved')
-            ->with('user', $event->author)
-            ->with('event', $event)
-            ->with('entity', $event->entity);
-        $email->send();
+        $email->html = view("emails.approved")
+            ->with("user", $event->author)
+            ->with("event", $event)
+            ->with("entity", $event->entity);
+        return $email->send();
     }
 
-    public static function sendBookingDeclined(Event $event)
+    public static function sendBookingDeclined(Event $event): bool
     {
-        $email = new EmailClient;
+        $email = new self("Din bokning blev inte godkänd");
         $email->recipient = $event->author->kth_username . "@kth.se";
-        $email->sender = "no-reply@datasektionen.se";
-        $email->subject = "Din bokning blev inte godkänd";
-        $email->html = view('emails.declined')
-            ->with('user', $event->author)
-            ->with('event', $event)
-            ->with('entity', $event->entity);
-        $email->send();
+        $email->html = view("emails.declined")
+            ->with("user", $event->author)
+            ->with("event", $event)
+            ->with("entity", $event->entity);
+        return $email->send();
     }
 
-    public static function sendBookingNotification(Event $event)
+    public static function sendBookingNotification(Event $event): bool
     {
-        $recipient = $event->entity->notify_email;
-        if ($recipient === null) {
-            return false;
-        }
-        $email = new EmailClient;
-        $email->recipient = $recipient;
-        $email->sender = "no-reply@datasektionen.se";
-        $email->subject = "Ny bokningsförfrågan för " . $event->entity->name;
-        $email->html = view('emails.notify')
-            ->with('user', $event->author)
-            ->with('event', $event)
-            ->with('entity', $event->entity);
-        $email->send();
+        $email = new self("Ny bokningsförfrågan för {$event->entity->name}");
+        $email->recipient = $event->entity->notify_email;
+        $email->html = view("emails.notify")
+            ->with("user", $event->author)
+            ->with("event", $event)
+            ->with("entity", $event->entity);
+        return $email->send();
     }
 
-    public static function sendBookingChanged(Event $oldEvent, Event $event, $dirty)
-    {
-        $recipient = $event->author->kth_username . '@kth.se';
-        if ($recipient === null) {
-            return false;
-        }
-        if (!preg_match("/(.*@.*\..*)(,.*@.*\..*)*/", $recipient)) {
-            return false;
-        }
-        $email = new EmailClient;
-        $email->recipient = $recipient;
-        $email->sender = "no-reply@datasektionen.se";
-        $email->subject = "Din bokning av " . $event->entity->name . " ändrades";
-        $email->html = view('emails.changed')
-            ->with('user', $event->author)
-            ->with('event', $event)
-            ->with('oldEvent', $oldEvent)
-            ->with('entity', $event->entity)
-            ->with('dirty', $dirty);
+    public static function sendBookingChanged(
+        Event $oldEvent,
+        Event $event,
+        array $dirty
+    ): bool {
+        $email = new self("Din bokning av {$event->entity->name} ändrades");
+        $email->recipient = $event->author->kth_username . "@kth.se";
+        $email->html = view("emails.changed")
+            ->with("user", $event->author)
+            ->with("event", $event)
+            ->with("oldEvent", $oldEvent)
+            ->with("entity", $event->entity)
+            ->with("dirty", $dirty);
 
-        $email->send();
+        return $email->send();
     }
 
-    public static function sendBookingChangedNotification(Event $oldEvent, Event $event, $dirty)
-    {
-        $recipient = $event->entity->notify_email;
-        if ($recipient === null) {
-            return false;
-        }
-        $email = new EmailClient;
-        $email->recipient = $recipient;
-        $email->sender = "no-reply@datasektionen.se";
-        $email->subject = "Bokningen " . $event->entity->name . " ändrades och måste granskas";
-        $email->html = view('emails.changed-notify')
-            ->with('event', $event)
-            ->with('oldEvent', $oldEvent)
-            ->with('entity', $event->entity)
-            ->with('dirty', $dirty);
-        $email->send();
+    public static function sendBookingChangedNotification(
+        Event $oldEvent,
+        Event $event,
+        array $dirty
+    ): bool {
+        $email = new self(
+            "Bokningen {$event->entity->name} ändrades och måste granskas"
+        );
+        $email->recipient = $event->entity->notify_email;
+        $email->html = view("emails.changed-notify")
+            ->with("event", $event)
+            ->with("oldEvent", $oldEvent)
+            ->with("entity", $event->entity)
+            ->with("dirty", $dirty);
+        return $email->send();
     }
 
-    public static function sendBookingDeleted(Event $event)
+    public static function sendBookingDeleted(Event $event): bool
     {
-        $recipient = $event->entity->notify_email;
-        if ($recipient === null) {
-            return false;
-        }
-        $email = new EmailClient;
-        $email->recipient = $recipient;
-        $email->sender = "no-reply@datasektionen.se";
-        $email->subject = "Bokningen " . $event->entity->name . " togs bort";
-        $email->html = view('emails.deleted')
-            ->with('event', $event)
-            ->with('entity', $event->entity);
-        $email->send();
+        $email = new self("Bokningen {$event->entity->name} togs bort");
+        $email->recipient = $event->entity->notify_email;
+        $email->html = view("emails.deleted")
+            ->with("event", $event)
+            ->with("entity", $event->entity);
+        $sentToEntityOwner = $email->send();
 
-        $email->recipient = $event->author->kth_username . '@kth.se';
-        $email->send();
+        $email->recipient = $event->author->kth_username . "@kth.se";
+        $sentToAuthor = $email->send();
+
+        return $sentToEntityOwner && $sentToAuthor;
     }
 }

--- a/app/Helpers/EmailClient.php
+++ b/app/Helpers/EmailClient.php
@@ -111,7 +111,7 @@ class EmailClient
 
     public static function sendBookingNotification(Event $event): bool
     {
-        $email = new self('Ny bokningsförfrågan för {$event->entity->name}');
+        $email = new self("Ny bokningsförfrågan för {$event->entity->name}");
         $email->recipient = $event->entity->notify_email;
         $email->html = view('emails.notify')
             ->with('user', $event->author)
@@ -121,7 +121,7 @@ class EmailClient
     }
 
     public static function sendBookingChanged(Event $oldEvent, Event $event, array $dirty): bool {
-        $email = new self('Din bokning av {$event->entity->name} ändrades');
+        $email = new self("Din bokning av {$event->entity->name} ändrades");
         $email->recipient = $event->author->kth_username . '@kth.se';
         $email->html = view('emails.changed')
             ->with('user', $event->author)
@@ -135,7 +135,7 @@ class EmailClient
 
     public static function sendBookingChangedNotification(Event $oldEvent, Event $event, array $dirty): bool {
         $email = new self(
-            'Bokningen {$event->entity->name} ändrades och måste granskas'
+            "Bokningen {$event->entity->name} ändrades och måste granskas"
         );
         $email->recipient = $event->entity->notify_email;
         $email->html = view('emails.changed-notify')
@@ -148,7 +148,7 @@ class EmailClient
 
     public static function sendBookingDeleted(Event $event): bool
     {
-        $email = new self('Bokningen {$event->entity->name} togs bort');
+        $email = new self("Bokningen {$event->entity->name} togs bort");
         $email->recipient = $event->entity->notify_email;
         $email->html = view('emails.deleted')
             ->with('event', $event)

--- a/config/spam.php
+++ b/config/spam.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'url' => env('SPAM_API_URL', 'https://spam.datasektionen.se/api/sendmail'),
+    'api_key' => env('SPAM_API_KEY'),
+];

--- a/resources/views/emails/changed.blade.php
+++ b/resources/views/emails/changed.blade.php
@@ -5,11 +5,11 @@
 <?php $green = 'style="color: #3a0;"'; ?>
 
 #Hej, {{ $user->name }}!
-    
+
 Din bokning har ändrats. Se nedan vad. Din bokning är inte bekräftad än. Du får ett nytt mejl när din bokning är handlagd.
 
-@if (isset($entity->reason) && strlen($entity->reason) > 0)
-**Anledning:** {{ $entity->reason }}
+@if (isset($event->reason) && strlen($event->reason) > 0)
+**Anledning:** {{ $event->reason }}
 @endif
 
 | Egenskap               | Gammalt värde          | Nytt värde |

--- a/resources/views/emails/declined.blade.php
+++ b/resources/views/emails/declined.blade.php
@@ -7,13 +7,13 @@ Din bokning blev inte godkänd!
 
 Detta mejl är en bekräftelse på att din bokning blivit avslagen. Nedan finns information kring bokningen.
 
-@if (isset($entity->reason) && strlen($entity->reason) > 0)
-**Anledning:** {{ $entity->reason }}
+@if (isset($event->reason) && strlen($event->reason) > 0)
+**Anledning:** {{ $event->reason }}
 @endif
 
 | Egenskap               | Värde                     |
 | ---------------------- | ------------------------- |
-| Bokningens start:      | {{ $event->start }}       | 
+| Bokningens start:      | {{ $event->start }}       |
 | Bokningens slut:       | {{ $event->end }}         |
 | Av vem:                | {{ $event->title }}       |
 | Anledning för bokning: | {{ $event->description }} |

--- a/resources/views/emails/deleted.blade.php
+++ b/resources/views/emails/deleted.blade.php
@@ -5,13 +5,13 @@
 
 Nedanstående bokning har **tagits bort** för {{ $entity->name }}. Tiden är alltså avbokad.
 
-@if (isset($entity->reason) && strlen($entity->reason) > 0)
-**Anledning:** {{ $entity->reason }}
+@if (isset($event->reason) && strlen($event->reason) > 0)
+**Anledning:** {{ $event->reason }}
 @endif
 
 | Egenskap               | Värde                     |
 | ---------------------- | ------------------------- |
-| Bokningens start:      | {{ $event->start }}       | 
+| Bokningens start:      | {{ $event->start }}       |
 | Bokningens slut:       | {{ $event->end }}         |
 | Av vem:                | {{ $event->title }}       |
 | Anledning för bokning: | {{ $event->description }} |


### PR DESCRIPTION
Fixes #21 

This PR goes slightly outside of the scope I first intended. The reason the bug was occurring, which I found also happens for declined and deleted events, was because `$event->reason` was being set and then we tried to read from `$entity->reason`. 

- I found that the preferred way to use `env` variables seem to be to only ever read from them in config files and then use the thing set there in the rest of the code. Because of caching. So I made a new file for `spam` which has 2 variables `url` and `api_key`. You would then use `url` like `config('spam.url')` instead of `env('SPAM_API_URL')`.
- I found the use of `curl` to be quite difficult to read so I replaced that with the included `GuzzleHttp` library. Then it was basically just `$client->post(uri, options)` to do a post request. Instead of some convoluted string concatenation of keys and values.
- Since PHP 7+ you can have more type hinting and stuff like that, so I've added that everywhere in the email client.
- Writing out the types I came across a lot of inconsistencies in return values. It sometimes returned `false` and sometimes returned nothing (`void`). I opted to always return a `bool` to show whether or not an email was sent. It is currently never used though.
- I wrote a constructor, mostly because `sender` was always set to the same value `no-reply@datasektionen.se`.
- Basically the same validation of recipient was done for most cases, so I moved that to `send` to always do the same validation everywhere.

Before:
![before](https://user-images.githubusercontent.com/23638900/152869594-398605a3-fd93-4f04-8275-66f13afd72c0.png)
After:
![after](https://user-images.githubusercontent.com/23638900/152869596-43fa3c8e-bd70-4b26-ad7a-14f8d33ead42.png)
