### PR TITLE
Add LoL-utrustning question

### DIFF
--- a/app/Http/Controllers/Admin/EntityAdminController.php
+++ b/app/Http/Controllers/Admin/EntityAdminController.php
@@ -68,6 +68,7 @@ class EntityAdminController extends BaseController
         $entity->notify_email = $request->input('notify_email');
         $entity->pls_group = $request->input('pls_group');
         $entity->alcohol_question = $request->input('alcohol_question') == 'yes';
+        $entity->lol_question = $request->input('lol_question') == 'yes';
         $entity->show_pending_bookings = $request->input('show_pending_bookings') == 'yes';
         $entity->part_of = $request->input('part_of');
         $entity->fa_icon = $request->input('fa_icon');
@@ -112,6 +113,7 @@ class EntityAdminController extends BaseController
         $entity->ruta_med_stuff = $request->input('ruta_med_stuff');
         $entity->notify_email = $request->input('notify_email');
         $entity->alcohol_question = $request->input('alcohol_question') == 'yes';
+        $entity->lol_question = $request->input('lol_question') == 'yes';
         $entity->show_pending_bookings = $request->input('show_pending_bookings') == 'yes';
         $entity->part_of = $request->input('part_of');
         $entity->fa_icon = $request->input('fa_icon');

--- a/app/Http/Controllers/Admin/ImportAdminController.php
+++ b/app/Http/Controllers/Admin/ImportAdminController.php
@@ -91,6 +91,7 @@ class ImportAdminController extends BaseController
             $event->approved = date("Y-m-d H:i:s");
             $event->approved_by = 1;
             $event->alcohol = 0;
+            $event->lol = 0;
             $event->save();
             $num++;
         }

--- a/app/Http/Controllers/EntityController.php
+++ b/app/Http/Controllers/EntityController.php
@@ -168,6 +168,7 @@ class EntityController extends BaseController
         $event->booked_by = Auth::user()->id;
         $event->entity_id = $entity->id;
         $event->alcohol = ($entity->alcohol_question && !$request->has('alcohol')) || ($request->has('alcohol') && $request->input('alcohol') === 'yes');
+        $event->lol = ($entity->lol_question && !$request->has('lol')) || ($request->has('lol') && $request->input('lol') === 'yes');
         $event->save();
 
         $validateDate = function ($date) {

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -165,6 +165,7 @@ class EventController extends BaseController
         //$event->alcohol = (!$request->has('alcohol')) || ($request->has('alcohol') && $request->input('alcohol') === 'yes');
         // TODO: Above line fucks up since the boolean value of some reason is being cast to int
         // If fixed, also change in view
+        // also fix for LoL, not just alcohol
 
         // isDirty() checks if something has been changed. If not, delete the duplicate event
         if (!$event->isDirty()) {

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -29,7 +29,7 @@ class Event extends Model
      *
      * @var array
      */
-    protected $casts = ['alcohol' => 'boolean'];
+    protected $casts = ['alcohol' => 'boolean', 'lol' => 'boolean'];
 
     /**
      * Defines relation the the entity it belongs to.

--- a/compose.yaml
+++ b/compose.yaml
@@ -48,4 +48,4 @@ services:
     image: ghcr.io/datasektionen/nyckeln-under-dorrmattan
     ports: [ 7002:7002 ]
     environment:
-      - KTH_ID=mathm
+      - KTH_ID=rmfseo

--- a/database/migrations/2025_03_07_142250_add_lol_question.php
+++ b/database/migrations/2025_03_07_142250_add_lol_question.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLoLQuestion extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('entities', function (Blueprint $table) {
+            $table->boolean('lol_question')->default(false);
+        });
+        Schema::table('events', function (Blueprint $table) {
+            $table->boolean('lol')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('lol');
+        });
+        Schema::table('entities', function (Blueprint $table) {
+            $table->dropColumn('lol_question');
+        });
+    }
+}

--- a/resources/views/admin/entities/edit.blade.php
+++ b/resources/views/admin/entities/edit.blade.php
@@ -53,6 +53,22 @@
 
         <div class="form-entry">
                 <span class="description">
+                    Fråga om behovet av speciell LoL-utrustning under bokning:
+                </span>
+            <div class="input horizontal">
+                <div class="radio">
+                    {!! Form::radio('lol_question', 'yes', $entity->lol_question, array('id' => 'lol_yes')) !!}
+                    <label for="lol_yes">Ja</label>
+                </div>
+                <div class="radio">
+                    {!! Form::radio('lol_question', 'no', !$entity->lol_question, array('id' => 'lol_no')) !!}
+                    <label for="lol_no">Nej</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-entry">
+                <span class="description">
                     Visa ännu ej handlagda bokningar för allmänheten:
                 </span>
             <div class="input horizontal">

--- a/resources/views/admin/entities/index.blade.php
+++ b/resources/views/admin/entities/index.blade.php
@@ -24,6 +24,7 @@
             <th>Pls-grupp</th>
             <th>Visa bokningsförslag?</th>
             <th>Fråga om alkohol?</th>
+            <th>Fråga om LoL?</th>
             <th>E-post vid händelser</th>
         </tr>
         @foreach ($entities as $entity)
@@ -34,6 +35,7 @@
                 <td>{{ $entity->pls_group }}</td>
                 <td>{{ $entity->show_pending_bookings ? 'Ja' : 'Nej' }}</td>
                 <td>{{ $entity->alcohol_question ? 'Ja' : 'Nej' }}</td>
+                <td>{{ $entity->lol_question ? 'Ja' : 'Nej' }}</td>
                 <td>{{ $entity->notify_email }}</td>
             </tr>
         @endforeach

--- a/resources/views/admin/entities/new.blade.php
+++ b/resources/views/admin/entities/new.blade.php
@@ -43,6 +43,22 @@
 
         <div class="form-entry">
             <span class="description">
+                Fråga om behovet av speciell LoL-utrustning under bokning:
+            </span>
+            <div class="input horizontal">
+                <div class="radio">
+                    {!! Form::radio('lol_question', 'yes', null, array('id' => 'lol_yes')) !!}
+                    <label for="lol_yes">Ja</label>
+                </div>
+                <div class="radio">
+                    {!! Form::radio('lol_question', 'no', null, array('id' => 'lol_no')) !!}
+                    <label for="lol_no">Nej</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-entry">
+            <span class="description">
                 Visa ännu ej handlagda bokningar för allmänheten:
             </span>
             <div class="input horizontal">

--- a/resources/views/emails/approved.blade.php
+++ b/resources/views/emails/approved.blade.php
@@ -16,6 +16,9 @@ Detta mejl är en bekräftelse på att din bokning blivit godkänd. Nedan finns 
 @if ($entity->alcohol_question)
 | Servering av alkohol:  | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
 @endif
+@if ($entity->lol_question)
+| Behov för LoL-utrustning: | {{ $event->lol ? 'Ja' : 'Nej' }} |
+@endif
 | Bokat av:              | {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se) |
 | Bokning skapad:        | {{ $event->created_at }}  |
 | Status:                | {{ $event->approved === null && $event->deleted_at === null ? 'Inte handlagd' : ($event->approved != null ? 'Godkänd' : 'Inte godkänd') }} |

--- a/resources/views/emails/changed-notify.blade.php
+++ b/resources/views/emails/changed-notify.blade.php
@@ -32,9 +32,16 @@ En bokning har ändrats. Se nedan vad. Du måste godkänna eller avböja bokning
 @endif
 @if ($entity->alcohol_question)
 @if (array_key_exists('alcohol', $dirty))
-| Anledning för bokning: | <span {!! $red !!}>~~{{ $oldEvent->alcohol ? 'Ja' : 'Nej' }}~~</span> | <span {!! $green !!}>{{ $event->alcohol ? 'Ja' : 'Nej' }}</span> |
+| Servering av alkohol:  | <span {!! $red !!}>~~{{ $oldEvent->alcohol ? 'Ja' : 'Nej' }}~~</span> | <span {!! $green !!}>{{ $event->alcohol ? 'Ja' : 'Nej' }}</span> |
 @else
-| Anledning för bokning: | {{ $oldEvent->alcohol ? 'Ja' : 'Nej' }} | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
+| Servering av alkohol:  | {{ $oldEvent->alcohol ? 'Ja' : 'Nej' }} | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
+@endif
+@endif
+@if ($entity->lol_question)
+@if (array_key_exists('lol', $dirty))
+| Behov för LoL-utrustning: | <span {!! $red !!}>~~{{ $oldEvent->lol ? 'Ja' : 'Nej' }}~~</span> | <span {!! $green !!}>{{ $event->lol ? 'Ja' : 'Nej' }}</span> |
+@else
+| Behov för LoL-utrustning: | {{ $oldEvent->lol ? 'Ja' : 'Nej' }} | {{ $event->lol ? 'Ja' : 'Nej' }} |
 @endif
 @endif
 | Bokat av:              | {{ $oldEvent->author->name }} ({{ $oldEvent->author->kth_username }}@kth.se) | {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se)  |

--- a/resources/views/emails/changed.blade.php
+++ b/resources/views/emails/changed.blade.php
@@ -36,9 +36,16 @@ Din bokning har ändrats. Se nedan vad. Din bokning är inte bekräftad än. Du 
 @endif
 @if ($entity->alcohol_question)
 @if (array_key_exists('alcohol', $dirty))
-| Anledning för bokning: | <span {!! $red !!}>~~{{ $oldEvent->alcohol ? 'Ja' : 'Nej' }}~~</span> | <span {!! $green !!}>{{ $event->alcohol ? 'Ja' : 'Nej' }}</span> |
+| Servering av alkohol:  | <span {!! $red !!}>~~{{ $oldEvent->alcohol ? 'Ja' : 'Nej' }}~~</span> | <span {!! $green !!}>{{ $event->alcohol ? 'Ja' : 'Nej' }}</span> |
 @else
-| Anledning för bokning: | {{ $oldEvent->alcohol ? 'Ja' : 'Nej' }} | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
+| Servering av alkohol:  | {{ $oldEvent->alcohol ? 'Ja' : 'Nej' }} | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
+@endif
+@endif
+@if ($entity->lol_question)
+@if (array_key_exists('lol', $dirty))
+| Behov för LoL-utrustning: | <span {!! $red !!}>~~{{ $oldEvent->lol ? 'Ja' : 'Nej' }}~~</span> | <span {!! $green !!}>{{ $event->lol ? 'Ja' : 'Nej' }}</span> |
+@else
+| Behov för LoL-utrustning: | {{ $oldEvent->lol ? 'Ja' : 'Nej' }} | {{ $event->lol ? 'Ja' : 'Nej' }} |
 @endif
 @endif
 | Bokat av:              | {{ $oldEvent->author->name }} ({{ $oldEvent->author->kth_username }}@kth.se) | {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se)  |

--- a/resources/views/emails/declined.blade.php
+++ b/resources/views/emails/declined.blade.php
@@ -20,6 +20,9 @@ Detta mejl är en bekräftelse på att din bokning blivit avslagen. Nedan finns 
 @if ($entity->alcohol_question)
 | Servering av alkohol:  | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
 @endif
+@if ($entity->lol_question)
+| Behov för LoL-utrustning: | {{ $event->lol ? 'Ja' : 'Nej' }} |
+@endif
 | Bokat av:              | {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se) |
 | Bokning skapad:        | {{ $event->created_at }}  |
 | Status:                | {{ $event->approved === null && $event->deleted_at === null ? 'Inte handlagd' : ($event->approved != null ? 'Godkänd' : 'Inte godkänd') }} |

--- a/resources/views/emails/deleted.blade.php
+++ b/resources/views/emails/deleted.blade.php
@@ -18,6 +18,9 @@ Nedanstående bokning har **tagits bort** för {{ $entity->name }}. Tiden är al
 @if ($entity->alcohol_question)
 | Servering av alkohol:  | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
 @endif
+@if ($entity->lol_question)
+| Behov för LoL-utrustning: | {{ $event->lol ? 'Ja' : 'Nej' }} |
+@endif
 | Bokat av:              | {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se) |
 | Bokning skapad:        | {{ $event->created_at }}  |
 | Status:                | Avbokad |

--- a/resources/views/emails/notify.blade.php
+++ b/resources/views/emails/notify.blade.php
@@ -14,6 +14,9 @@ En ny bokningsförfrågan har inkommit för {{ $entity->name }}. Se nedan. [Du k
 @if ($entity->alcohol_question)
 | Servering av alkohol:  | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
 @endif
+@if ($entity->lol_question)
+| Behov för LoL-utrustning: | {{ $event->lol ? 'Ja' : 'Nej' }} |
+@endif
 | Bokat av:              | {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se) |
 | Bokning skapad:        | {{ $event->created_at }}  |
 | Status:                | {{ $event->approved === null && $event->deleted_at === null ? 'Inte handlagd' : ($event->approved != null ? 'Godkänd' : 'Inte godkänd') }} |

--- a/resources/views/emails/reviewing.blade.php
+++ b/resources/views/emails/reviewing.blade.php
@@ -16,6 +16,9 @@ Detta mejl innebär inte att din bokning är bekräftad. Du får ett nytt mejl n
 @if ($entity->alcohol_question)
 | Servering av alkohol:  | {{ $event->alcohol ? 'Ja' : 'Nej' }} |
 @endif
+@if ($entity->lol_question)
+| Behov för LoL-utrustning: | {{ $event->lol ? 'Ja' : 'Nej' }} |
+@endif
 | Bokat av:              | {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se) |
 | Bokning skapad:        | {{ $event->created_at }}  |
 | Status:                | {{ $event->approved === null && $event->deleted_at === null ? 'Inte handlagd' : ($event->approved != null ? 'Godkänd' : 'Inte godkänd') }} |

--- a/resources/views/events/edit.blade.php
+++ b/resources/views/events/edit.blade.php
@@ -45,7 +45,7 @@
             {!! Form::text('reason_edit', NULL, ['placeholder' => 'T.ex. "Ett annat event tog bokningstiden."']) !!}
         </div>
         {{--
-        TODO: Enable when controller handles it
+        TODO: Enable when controller handles it; also LoL
         @if ($event->entity->alcohol_question)
         <div class="form-entry">
             <span class="description">

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -70,6 +70,12 @@
                         <td> {{ $event->alcohol ? 'Ja' : 'Nej' }}</td>
                     </tr>
                 @endif
+                @if ($event->entity->lol_question)
+                    <tr>
+                        <td>Behövas speciell LoL-utrustning:</td>
+                        <td> {{ $event->lol ? 'Ja' : 'Nej' }}</td>
+                    </tr>
+                @endif
                 <tr>
                     <td>Bokat av:</td>
                     <td> {{ $event->author->name }} ({{ $event->author->kth_username }}@kth.se)</td>

--- a/resources/views/includes/book-form.blade.php
+++ b/resources/views/includes/book-form.blade.php
@@ -51,6 +51,21 @@
             </div>
         </div>
     @endif
+    @if ($entity->lol_question)
+        <div class="form-entry">
+            <span class="description">
+                Kommer det att behövas någon speciell Ljud-och-Ljus utrustning? (t.ex. mikrofoner, högtalare, kablage)
+            </span>
+            <div class="horizontal">
+                <div class="radio">
+                    {!! Form::radio('lol', 'yes', false, ['id' => 'lol']) !!} <label for="lol">Ja</label>
+                </div>
+                <div class="radio">
+                    {!! Form::radio('lol', 'no', true, ['id' => 'nolol']) !!} <label for="nolol">Nej</label>
+                </div>
+            </div>
+        </div>
+    @endif
     @if ($entity->contract_url !== null)
         <div class="form-entry">
             <span class="description">

--- a/resources/views/includes/week-component.blade.php
+++ b/resources/views/includes/week-component.blade.php
@@ -68,6 +68,9 @@
                                         @if ($entity->alcohol_question)
                                             <br>Alkohol: {{ $event->alcohol ? 'Ja' : 'Nej' }}
                                         @endif
+                                        @if ($entity->lol_question)
+                                            <br>LoL: {{ $event->lol ? 'Ja' : 'Nej' }}
+                                        @endif
                                     @endif
                                 </div>
                             </a>


### PR DESCRIPTION
LoL-ansvarig wants a way to tell if the people using META are using any special equipment, so he can know whether to approve separate bookings for e.g. microphones.

Ideally, Pandora would support some kind of "dual-booking" for multiple entities, wherein both META and LoL-equipment could be booked at the same time for the same reason (and be moved together when edited, etc.). However, that would require considerable effort to implement, disproportionate to the real benefit of this feature.

Instead, this PR adds a new question to opt-in entities, making it so the person reviewing LoL bookings only needs to check if simultaneous META bookings require something special and so clash. There's still the edge case of META being booked (with need for equipment) *after* a separate LoL-equipment booking has already been approved, but I don't think there's anything that can be easily done to fix this. (META bookings are shown on the LoL calendar, so it's easy to check them, but not the other way around, so Lokalchef can't easily see if someone already has LoL when reviewing META booking requests)